### PR TITLE
Email translation

### DIFF
--- a/app/models/mention_mailer.rb
+++ b/app/models/mention_mailer.rb
@@ -14,6 +14,6 @@ class MentionMailer < ActionMailer::Base
   def notify_mentioning(issue, journal, user)
     @issue = issue
     @journal = journal
-    mail(to: user.mail, subject: "[#{@issue.project.name} - #{@issue.tracker.name}##{@issue.id}] You were mentioned in: #{@issue.subject}")
+    mail(to: user.mail, subject: "[#{@issue.project.name} - #{@issue.tracker.name} ##{@issue.id}] #{l(:subject_you_were_mentioned)} #{@issue.subject}")
   end
 end

--- a/app/views/mention_mailer/notify_mentioning.html.erb
+++ b/app/views/mention_mailer/notify_mentioning.html.erb
@@ -1,9 +1,8 @@
-<h4><%= link_to "[#{@issue.project.name} - #{@issue.tracker.name}##{@issue.id}] #{@issue.subject}", issue_url(@issue) %></h4>
 
-<br /><br />
+<p><%= l(:html_you_were_mentioned, :login => @journal.user.login, :created_on => (format_time @journal.created_on, true)) %></p>
 
-<i>You were mentioned by <strong><%= @journal.user.login %></strong> on <strong><%=  @journal.created_on.localtime.to_s %></strong></i>
+<hr />
 
-<br /><br />
+<h4><%= link_to "#{@issue.tracker.name} ##{@issue.id}: #{@issue.subject}", issue_url(@issue) %></h4>
 
 <%= textilizable(@journal, :notes, {:headings => false, :only_path => false}) -%>

--- a/app/views/mention_mailer/notify_mentioning.html.erb
+++ b/app/views/mention_mailer/notify_mentioning.html.erb
@@ -1,5 +1,5 @@
 
-<p><%= l(:html_you_were_mentioned, :login => @journal.user.login, :created_on => (format_time @journal.created_on, true)) %></p>
+<p><%= l(:html_you_were_mentioned, :login => @journal.user.login, :created_on => (format_time @journal.created_on, true)).html_safe %></p>
 
 <hr />
 

--- a/app/views/mention_mailer/notify_mentioning.text.erb
+++ b/app/views/mention_mailer/notify_mentioning.text.erb
@@ -1,6 +1,7 @@
-[<%= @issue.project.name %> - <%= @issue.tracker.name %>#<%= @issue.id %>] <%= @issue.subject %>
+<%= @issue.tracker.name %> #<%= @issue.id %>: <%= @issue.subject %>
+
 <%= issue_url(@issue) %>
 
-You were mentioned by <%= @journal.user.login %> on <%=  @journal.created_on.localtime.to_s %>
+<%= l(:text_you_were_mentioned, :login => @journal.user.login, :created_on => (format_time @journal.created_on, true)) %>
 
 <%= @journal.notes %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,3 +1,4 @@
 en:
   html_you_were_mentioned: "Sie wurden von <strong>%{login}</strong> um <strong>%{created_on}</strong> erwähnt."
   text_you_were_mentioned: "Sie wurden von %{login} um %{created_on} erwähnt."
+  subject_you_were_mentioned: "Sie wurden erwähnt in:"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,3 @@
+en:
+  html_you_were_mentioned: "Sie wurden von <strong>%{login}</strong> um <strong>%{created_on}</strong> erwähnt."
+  text_you_were_mentioned: "Sie wurden von %{login} um %{created_on} erwähnt."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,4 @@
 en:
   html_you_were_mentioned: "You were mentioned by <strong>%{login}</strong> on <strong>%{created_on}.</strong>"
   text_you_were_mentioned: "You were mentioned by %{login} on %{created_on}."
+  subject_you_were_mentioned: "You were mentioned in:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,3 @@
-# English strings go here for Rails i18n
 en:
-  # my_label: "My label"
+  html_you_were_mentioned: "You were mentioned by <strong>%{login}</strong> on <strong>%{created_on}.</strong>"
+  text_you_were_mentioned: "You were mentioned by %{login} on %{created_on}."


### PR DESCRIPTION
Hi @tainewoo,

This PR adds translation files for `en` and `de`. And it moves subject line and text from html and text bodies into the locale config.

It also tries to adjust layout to match other mail templates.